### PR TITLE
Add link checker as a GitHub Action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/links-fail-fast.yml
+++ b/.github/workflows/links-fail-fast.yml
@@ -1,0 +1,18 @@
+name: Links (Fail Fast)
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        uses: lycheeverse/lychee-action@v1.5.0
+        with:
+          fail: true
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Create Issue From File
         if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@v3
+        uses: peter-evans/create-issue-from-file@v4
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,6 +1,7 @@
 name: Links
 
 on:
+  push:
   repository_dispatch:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,7 +1,6 @@
 name: Links
 
 on:
-  push:
   repository_dispatch:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,27 @@
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * *"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.5.0
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v3
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
Hi,

This PR adds a GitHub Action to check for broken links in the Markdown README file. It is composed of two workflows, one that will periodically check the links (every day) and open an issue automatically, and the other one that will be triggered on PR and on pushes.

I believe this will help to maintain the 192 links currently present in the README :)

EDIT: forgot to mention, there also is a Dependabot configuration file, to help maintain up-to-date the Actions used.