### PR TITLE
Add NullSec Linux to GNU/Linux security hardening tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 - [SCAP Workbench](https://www.open-scap.org/tools/scap-workbench/) - GUI for oscap
 - [Tiger - The Unix security audit and intrusion detection tool](https://www.nongnu.org/tiger/) (might be outdated)
 - [otseca](https://github.com/trimstray/otseca) - Open source security auditing tool to search and dump system configuration. It allows you to generate reports in HTML or RAW-HTML formats.
+- [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Security-focused Linux distribution with 135+ integrated hardening and auditing tools. Includes automated CIS benchmark checking, kernel hardening scripts, and security baseline enforcement.
 - [SUDO_KILLER](https://github.com/TH3xACE/SUDO_KILLER) - A tool to identify sudo rules' misconfigurations and vulnerabilities within sudo
 - [CIS Benchmarks Audit](https://github.com/finalduty/cis_benchmarks_audit) - bash script which performs tests against your CentOS system to give an indication of whether the running server may comply with the CIS v2.2.0 Benchmarks for CentOS (only CentOS 7 for now)
 


### PR DESCRIPTION
## Addition

Added **NullSec Linux** to the 'Tools to check security hardening → GNU/Linux' section.

### About NullSec Linux

[NullSec Linux](https://github.com/bad-antics/nullsec-linux) is a security-focused Linux distribution with 135+ integrated hardening and auditing tools including:

- Automated CIS benchmark checking
- Kernel hardening scripts  
- Security baseline enforcement
- Pre-configured security policies
- Integration with Lynis, OpenSCAP, and other standard tools

### Why it fits

NullSec Linux provides a comprehensive toolkit for security hardening audits, complementing existing tools like Lynis and OpenSCAP with an all-in-one distribution approach.

Thank you for maintaining this excellent resource!