### PR TITLE
Add VPS-Harden to GNU/Linux hardening tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 
 ### GNU/Linux
 
+- [VPS-Harden](https://github.com/ranjith-src/vps-harden) - idempotent Bash script to harden Debian/Ubuntu servers with dry-run mode, lockout protection, and security scorecard
 - [Linux Server Hardener](https://github.com/pratiktri/server_init_harden) - for Debian/Ubuntu (2019)
 - [Bastille Linux](http://bastille-linux.sourceforge.net/) - outdated
 


### PR DESCRIPTION
Adding [VPS-Harden](https://github.com/ranjith-src/vps-harden) — an idempotent Bash script to harden Debian/Ubuntu servers.

**What it does:** 14 modules covering SSH hardening, UFW firewall, fail2ban, kernel sysctl, Netbird VPN, SOPS+age secrets, auditd monitoring, unattended upgrades, and more.

**Why it fits this list:**
- Single Bash file, zero dependencies — applies hardening, not just checks it
- Idempotent with dry-run mode and lockout protection
- Grouped security scorecard to verify posture
- Active development (latest release: v1.3.6, Feb 2026)

Placed under "Tools to apply security hardening > GNU/Linux" alongside Linux Server Hardener and Bastille Linux.