### PR TITLE
Add SSL Certificate Monitor - open-source SSL/TLS certificate expiry monitoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 - [CryptoLyzer](https://github.com/c0r0n3r/cryptolyzer) - Fast, flexible and comprehensive server cryptographic protocol (TLS, SSL, SSH, DNSSEC) and related setting (HTTP headers, DNS records) analyzer and fingerprint (JA3, HASSH tag) generator with Python API and CLI.
 - [SSLyze](https://github.com/nabla-c0d3/sslyze) - Fast and powerful SSL/TLS scanning library.
 - [testssl.sh](https://github.com/drwetter/testssl.sh) - Testing TLS/SSL encryption anywhere on any port
+- [SSL Certificate Monitor](https://github.com/brancogao/ssl-certificate-monitor) - Open-source SSL/TLS certificate expiry monitoring tool with email alerts
 
 ### SSH
 


### PR DESCRIPTION
## Description

Add [SSL Certificate Monitor](https://github.com/brancogao/ssl-certificate-monitor) to the TLS/SSL Tools section.

### What it does:
- Monitor SSL/TLS certificate expiration dates
- Email alerts before certificates expire
- Real-time certificate chain validation
- Multi-domain monitoring dashboard
- Open-source and self-hostable on Cloudflare Workers

### Why it's useful:
- Prevents expired certificate incidents
- Easy to deploy (serverless)
- Free and open-source alternative to commercial monitoring services

### Links:
- GitHub: https://github.com/brancogao/ssl-certificate-monitor
- Live Demo: https://ssl-certificate-monitor.autocompany.workers.dev

## Checklist
- [x] The tool is relevant to security hardening (TLS/SSL monitoring)
- [x] The tool is open-source
- [x] The description follows the format of other entries