### PR TITLE
Add cloud-audit to Cloud tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 ### Cloud
 
 - [toniblyx/my-arsenal-of-aws-security-tools](https://github.com/toniblyx/my-arsenal-of-aws-security-tools) - List of open source tools for AWS security: defensive, offensive, auditing, DFIR, etc.
+- [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - AWS security auditing CLI that runs 17 checks across IAM, S3, EC2, VPC, and RDS with remediation engine generating AWS CLI commands and Terraform snippets.
 
 ## Tools to apply security hardening
 


### PR DESCRIPTION
Add [cloud-audit](https://github.com/gebalamariusz/cloud-audit) to the Cloud section under "Tools to check security hardening".

cloud-audit is an AWS security auditing CLI that runs 17 checks across IAM, S3, EC2, VPC, and RDS. It includes a remediation engine that generates AWS CLI commands and Terraform snippets for fixing misconfigurations.

- Open source, Python-based
- Zero config — uses existing AWS credentials
- Outputs prioritized report with actionable fixes