### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,9 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 ### SSH
 
 - [NIST IR 7966 - Security of Interactive and Automated Access Management Using Secure Shell (SSH)](https://nvlpubs.nist.gov/nistpubs/ir/2015/NIST.IR.7966.pdf)
-- [ANSSI - (Open)SSH secure use recommendations](https://www.ssi.gouv.fr/en/guide/openssh-secure-use-recommendations/)
 - [Linux Audit - OpenSSH security and hardening](https://linux-audit.com/audit-and-harden-your-ssh-configuration/)
-- [Positron Security SSH Hardening Guides](https://www.sshaudit.com/hardening_guides.html) (2017-2018) - focused on crypto algorithms
 - [stribika - Secure Secure Shell](https://stribika.github.io/2015/01/04/secure-secure-shell.html) (2015) - some algorithm recommendations might be slightly outdated
-- [Applied Crypto Hardening: bettercrypto.org](https://bettercrypto.org/) - handy reference on how to configure the most common services’ crypto settings (TLS/SSL, PGP, SSH and other cryptographic tools)
 - [IETF - Key Exchange (KEX) Method Updates and Recommendations for Secure Shell (SSH) draft-ietf-curdle-ssh-kex-sha2-10](https://tools.ietf.org/html/draft-ietf-curdle-ssh-kex-sha2-10) - update to the recommended set of key exchange methods for use in the Secure Shell (SSH) protocol to meet evolving needs for stronger security. This document updates RFC 4250.
-- [Gravitational - How to SSH Properly](https://gravitational.com/blog/how-to-ssh-properly) - how to configure SSH to use certificates and two-factor authentication
 
 ### TLS/SSL
 


### PR DESCRIPTION
Hello, I spotted some errors in your advising for SSH. I'll list what I noted below.

These 3 sources referenced for SSH security no longer exist or may have been entered incorrectly.
https://www.ssi.gouv.fr/en/guide/openssh-secure-use-recommendations/
https://www.sshaudit.com/hardening_guides.html
https://bettercrypto.org/


These sources listed below are deprecated by modern standards and contain 'expired' time bound advice. 
https://goteleport.com/blog/how-to-ssh-properly/
 - TOTP apps, while still used, are growing obsolete to hardware keys and push-bashed mfa.
 - RSA keys are no longer the modern standard. This should be ssh-keygen -t ed25519.
 - This article suggests extremely long lived certs, ie 1 year certs. This is far too long.
 - While manual CA management is still something I'm personally not opposed to if it is done well, the article fails to mention vaults and the security tradeoffs many devs prefer with them, opposed to manual.
 - If you use a bastion host, then you either need to run it through a proxy or have a backup bastion server that is also whitelisted.
 - Overall this article contains out of date advice and subpar practices. It is also redundant when paired with what you've already provided for SSH, providing no new information. Given all that, I'd suggest removing this article from the SSH section.
 
 I considered adding additional sources or perhaps briefly explaining and pointing sources to cryptography concerning SSH, but the sources you listed are rather robust and should have all the info anyway. Though I'd recommend maybe describing or summarizing these documents as well. People pick up a lot more on what they read if they go in with a general idea, which really only needs to be like 100 to 1000 words. 