### PR TITLE
Add BunkerWeb to Web Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This is work in progress: please contribute by sending your suggestions. You may
       - [Apache Tomcat](#apache-tomcat)
       - [Eclipse Jetty](#eclipse-jetty)
       - [Microsoft IIS](#microsoft-iis)
+      - [BunkerWeb](#bunkerweb)
     - [Mail Servers](#mail-servers)
     - [FTP Servers](#ftp-servers)
     - [Database Servers](#database-servers)
@@ -241,6 +242,10 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 #### Microsoft IIS
 
 - [CIS Microsoft IIS Benchmarks](https://learn.cisecurity.org/benchmarks)
+
+#### BunkerWeb
+
+- [BunkerWeb documentation](https://docs.bunkerweb.io/latest/) - BunkerWeb is a next-generation, open-source Web Application Firewall (WAF/WAAP).
 
 ### Mail Servers
 - [MDaemon - 15 Best Practices for Protecting Your Email](https://blog.mdaemon.com/15-best-practices-for-protecting-your-email-with-security-gateway) - Generic recommandations but based on MDaemon Security Gateway for Email Servers


### PR DESCRIPTION
## Summary

This PR adds BunkerWeb to the `Services > Web Servers` section of the list.

Changes:
- add `BunkerWeb` to the Table of Contents under `Web Servers`
- add a new `#### BunkerWeb` subsection in `README.md`
- link to the official documentation with a concise, objective description

## Why

BunkerWeb is an open-source web application firewall and reverse proxy focused on protecting web applications and APIs. It fits this repository as a web-server hardening resource and is best represented here through its official documentation.