### PR TITLE
Add VPS-SECURE — Ubuntu 24.04 hardening script

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 
 - [Linux Server Hardener](https://github.com/pratiktri/server_init_harden) - for Debian/Ubuntu (2019)
 - [Bastille Linux](http://bastille-linux.sourceforge.net/) - outdated
+- [VPS-SECURE](https://github.com/rockballslab/vps-secure) - One-command Ubuntu 24.04 LTS hardening script. 15-minute install. Lynis score 86/100 (vs ~55 on a bare VPS). Implements CIS Benchmark ~80%, DISA STIG ~70%. Includes CrowdSec IPS, AIDE file integrity, rkhunter, auditd, UFW, Endlessh honeypot, DNS-over-TLS, and a real-time monitoring dashboard with Telegram alerts.
 
 ### Windows
 


### PR DESCRIPTION
## What this adds

[VPS-SECURE](https://github.com/rockballslab/vps-secure) under **Tools to apply security hardening → GNU/Linux**.

## Why it fits

VPS-SECURE is an open-source bash script that automates full Ubuntu 24.04 LTS hardening in a single command (~15 minutes). It covers the major standards referenced in this list:

- **CIS Benchmark** ~80% compliance
- **DISA STIG** ~70% compliance
- **Lynis score: 86/100** (vs ~55 on a bare VPS)

Stack: CrowdSec IPS, AIDE file integrity monitoring, rkhunter, auditd, UFW + Docker NAT rules, Endlessh honeypot, DNS-over-TLS, kernel hardening (35 sysctl params).

Includes a real-time monitoring dashboard (Docker) and Telegram alerts.

## Checklist

- [x] Open-source (MIT licence)
- [x] Actively maintained (latest release 2026)
- [x] Documentation in English
- [x] Tested on production Ubuntu 24.04 LTS KVM VPS