### PR TITLE
Add NoID Privacy (Windows 11 hardening engine, PowerShell)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 - [Automated-AD-Setup](https://github.com/OneLogicalMyth/Automated-AD-Setup) - A PowerShell script that aims to have a fully configured domain built in under 10 minutes, but also apply security configuration and hardening
 - [mackwage/windows_hardening.cmd](https://gist.github.com/mackwage/08604751462126599d7e52f233490efe) - Script to perform some hardening of Windows 10
 - [Windows 10/11 Hardening Script by ZephrFish](https://github.com/ZephrFish/WindowsHardeningScript) - PowerShell script to harden Windows 10/11
+- [NoID Privacy](https://github.com/NexusOne23/noid-privacy) - PowerShell engine to harden Windows 11 privacy and security (633 settings, 7 modules) on top of the Microsoft Security Baseline; every change is backed up, applied, verified and reversible. No external binaries, GPL-3.0.
 
 ### TLS/SSL
 


### PR DESCRIPTION
Adds **NoID Privacy** to *Tools → Tools to apply security hardening → Windows* (alongside Hardentools / the ZephrFish script).

An open-source (GPL-3.0) PowerShell engine that hardens Windows 11 privacy & security — 633 settings across 7 modules, built on top of the Microsoft Security Baseline. Every change is backed up, applied, verified and reversible (BAVR). No external binaries (100% native PowerShell, no LGPO/DLLs/downloads).

**Disclosure:** I'm the author of this project.