### PR TITLE
Add DomScan to DNS tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 ### DNS
 
 - [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC, BIMI, MTA-STS configuration and provides AI-powered fix suggestions.
+- [DomScan](https://domscan.net) - Domain intelligence with DNS, WHOIS/RDAP, SSL/TLS and email-security (SPF/DKIM/DMARC/DNSSEC) checks, plus an API and MCP server.
 
 ## Tools to apply security hardening
 


### PR DESCRIPTION
Adds **DomScan** (https://domscan.net), a domain intelligence service for DNS, WHOIS/RDAP, SSL/TLS, subdomain discovery, valuation and typosquatting (API and MCP server). Added to the most relevant section in the existing format.