### PR TITLE
Add Cynative to cloud security tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 ### Cloud
 
 - [toniblyx/my-arsenal-of-aws-security-tools](https://github.com/toniblyx/my-arsenal-of-aws-security-tools) - List of open source tools for AWS security: defensive, offensive, auditing, DFIR, etc.
-- [Cynative](https://github.com/cynative/cynative) - Open-source cybersecurity deep research agent for cloud, runtime and code - connects to AWS, GCP, Azure, K8s, GitHub & GitLab. Read-only CLI built in Go.
+- [Cynative](https://github.com/cynative/cynative) - Open-source framework for security agents with live, read-only access to your infrastructure (connects to AWS, GCP, Azure, self-managed Kubernetes, GitHub and GitLab).
 
 ### DNS
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 ### Cloud
 
 - [toniblyx/my-arsenal-of-aws-security-tools](https://github.com/toniblyx/my-arsenal-of-aws-security-tools) - List of open source tools for AWS security: defensive, offensive, auditing, DFIR, etc.
+- [Cynative](https://github.com/cynative/cynative) - Open-source cybersecurity deep research agent for cloud, runtime and code - connects to AWS, GCP, Azure, K8s, GitHub & GitLab. Read-only CLI built in Go.
 
 ### DNS
 


### PR DESCRIPTION
Added Cynative to the list of open-source cybersecurity tools for cloud.

Cynative is an open-source framework for security agents with live, read-only access to your infrastructure (connects to AWS, GCP, Azure, self-managed Kubernetes, GitHub and GitLab).