### PR TITLE
Add Nutilz SSL Checker to TLS/SSL testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 - [CryptoLyzer](https://github.com/c0r0n3r/cryptolyzer) - Fast, flexible and comprehensive server cryptographic protocol (TLS, SSL, SSH, DNSSEC) and related setting (HTTP headers, DNS records) analyzer and fingerprint (JA3, HASSH tag) generator with Python API and CLI.
 - [SSLyze](https://github.com/nabla-c0d3/sslyze) - Fast and powerful SSL/TLS scanning library.
 - [testssl.sh](https://github.com/drwetter/testssl.sh) - Testing TLS/SSL encryption anywhere on any port
+- [Nutilz SSL Checker](https://nutilz.com/ssl-checker) - Free browser-based SSL/TLS certificate checker: expiry countdown, issuer, SAN list, cipher suite and TLS version, no signup or install required.
 
 ### SSH
 


### PR DESCRIPTION
Adds [Nutilz SSL Checker](https://nutilz.com/ssl-checker) to the TLS/SSL testing tools section, alongside SSLyze and testssl.sh.

Free, no-signup, browser-based SSL/TLS certificate checker. Enter any domain and get: certificate validity + expiry countdown (with visual warning at <30/<90 days), issuer org/CN, subject CN, SAN list, serial number, cipher suite, and negotiated TLS version. Useful as a quick web-based alternative to the CLI tools already listed here for anyone who just wants a one-off check without installing anything.