### PR TITLE
Add Nutilz DMARC Report Analyzer to DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 ### DNS
 
 - [IntoDNS.ai](https://intodns.ai) - Free DNS and email security scanner. Checks SPF, DKIM, DMARC, DNSSEC, BIMI, MTA-STS configuration and provides AI-powered fix suggestions.
+- [Nutilz DMARC Report Analyzer](https://nutilz.com/dmarc-analyzer) - Free tool to parse DMARC aggregate (RUA) report XML/XML.GZ files and see which sending IPs passed or failed SPF/DKIM authentication. 100% client-side, nothing uploaded.
 
 ## Tools to apply security hardening
 


### PR DESCRIPTION
Adds Nutilz DMARC Report Analyzer (https://nutilz.com/dmarc-analyzer) to the DNS section under "Tools to check security hardening", next to IntoDNS.ai.

While IntoDNS.ai does a live scan of a domain's current DNS/email-auth records, this tool covers a different, complementary use case: parsing the DMARC aggregate (RUA) report XML/XML.GZ files that mailbox providers already send you, and showing per-sender SPF/DKIM pass/fail results. Entirely client-side (DOMParser + DecompressionStream) — the report never leaves the browser. Free, no signup.