### PR TITLE
Add sshd_lint to SSH tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 
 - [CryptoLyzer](https://github.com/c0r0n3r/cryptolyzer) - Fast, flexible and comprehensive server cryptographic protocol (TLS, SSL, SSH, DNSSEC) and related setting (HTTP headers, DNS records) analyzer and fingerprint (JA3, HASSH tag) generator with Python API and CLI.
 - [ssh-audit](https://github.com/arthepsy/ssh-audit) - SSH server auditing (banner, key exchange, encryption, mac, compression, compatibility, security, etc)
+- [sshd_lint](https://github.com/capitan0n/sshd-lint) - Zero-dependency, offline static analyzer for OpenSSH sshd_config files. Detects insecure directives, deprecated algorithms, and misconfigurations without connecting to a running server.
 
 ### Hardware - CPU - BIOS - UEFI
 


### PR DESCRIPTION
This PR adds `sshd_lint` to the SSH subsection under "Tools to check security hardening".

**What it is:** A zero-dependency, offline static analyzer for OpenSSH `sshd_config` files, written in Python (stdlib only). Published on PyPI and available as `pip install sshd-lint`.

**Why it fits:** The existing SSH tools in the list (`ssh-audit`, `CryptoLyzer`) perform runtime auditing by connecting to a live SSH server. `sshd_lint` complements them by analyzing the server configuration file itself, offline — useful for CI/CD pipelines, pre-deployment review, and environments where the server isn't reachable during audit. It detects insecure directives, deprecated algorithms (with correct handling of `+`/`-`/`^` prefix syntax), and misconfigurations, including cumulative directive semantics and `Include` directive resolution.

**Repo:** https://github.com/capitan0n/sshd-lint
**License:** MIT
**Language:** Python 3.9+ (zero dependencies)