### PR TITLE
Add Raccoon (new macOS subsection under Tools to check security hardening)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This is work in progress: please contribute by sending your suggestions. You may
   - [Tools to check security hardening](#tools-to-check-security-hardening)
     - [GNU/Linux](#gnulinux-1)
     - [Windows](#windows-1)
+    - [macOS](#macos-1)
     - [Network Devices](#network-devices-1)
     - [TLS/SSL](#tlsssl-1)
     - [SSH](#ssh-1)
@@ -350,6 +351,10 @@ See also [Active Directory](#active-directory) and [ADFS](#adfs) below.
 - [HardeningAuditor](https://github.com/cottinghamd/HardeningAuditor/) - Scripts for comparing Microsoft Windows compliance with the Australian ASD 1709 & Office 2016 Hardening Guides
 - [PingCastle](https://www.pingcastle.com/) - Tool to check the security of Active Directory
 - [MDE-AuditCheck](https://github.com/olafhartong/MDE-AuditCheck) - Tool to check that Windows audit settings are properly configured in the GPO for Microsoft Defender for Endpoint
+
+### macOS
+
+- [Raccoon](https://github.com/thousandflowers/Raccoon) - Bash toolkit that audits macOS hosts against CIS-mapped checks (firewall, FileVault, SIP, Gatekeeper, login items), reports in text, JSON, CSV, Markdown or RTF, and runs the same audit across many Macs over SSH without installing anything on them. Optional `--fix` backs up every change first.
 
 ### Network Devices
 


### PR DESCRIPTION
Adds a `### macOS` subsection under **Tools to check security hardening**, plus one entry, and the matching TOC line.

The list already has a macOS section in the guides half (the ERNW IPv6 guide), but the tools half only covers GNU/Linux, Windows, network devices, TLS/SSL, SSH, hardware, Docker, Cloud and DNS — there is currently nowhere to put a macOS host checker. The subsection is placed after Windows, mirroring the order used in the guides half.

Raccoon audits a Mac against CIS-mapped checks (firewall, FileVault, SIP, Gatekeeper, login items), renders reports as text, JSON, CSV, Markdown or RTF from a single data model, and runs the same audit across many Macs over SSH stdin — the remote machines need only bash, macOS and an open SSH server, nothing is installed on them. `--fix` is opt-in and backs up every destructive change to a timestamped directory before applying it; it deliberately refuses changes that would silently weaken a setup, such as setting a public DNS resolver or stripping Gatekeeper quarantine flags.

https://github.com/thousandflowers/Raccoon — MIT, pure Bash, 130 stars, `brew install thousandflowers/tap/raccoon`.

Comparable entries already listed: CIS Benchmarks Audit, CIS Debian Hardening, VPS Security Audit Script (all Bash host auditors, for other platforms).